### PR TITLE
restore default nettype to wire

### DIFF
--- a/rtl/afifo.v
+++ b/rtl/afifo.v
@@ -740,3 +740,7 @@ module afifo #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/apbslave.v
+++ b/rtl/apbslave.v
@@ -215,3 +215,7 @@ module	apbslave #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axi2axi3.v
+++ b/rtl/axi2axi3.v
@@ -891,3 +891,7 @@ module	axi2axi3 #(
 //
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axi2axilite.v
+++ b/rtl/axi2axilite.v
@@ -1083,3 +1083,7 @@ module axi2axilite #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axi32axi.v
+++ b/rtl/axi32axi.v
@@ -375,3 +375,7 @@ module	axi32axi #(
 //
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axi3reorder.v
+++ b/rtl/axi3reorder.v
@@ -744,3 +744,7 @@ module	axi3reorder #(
 `endif
 	// }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axi_addr.v
+++ b/rtl/axi_addr.v
@@ -238,3 +238,7 @@ module	axi_addr #(
 	// Verilator lint_on UNUSED
 	// }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axidma.v
+++ b/rtl/axidma.v
@@ -2740,3 +2740,7 @@ module	axidma #(
 	// None (currently)
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axidouble.v
+++ b/rtl/axidouble.v
@@ -1198,3 +1198,7 @@ module	axidouble #(
 	end endgenerate
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axiempty.v
+++ b/rtl/axiempty.v
@@ -435,3 +435,7 @@ module axiempty #(
 	//
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axil2apb.v
+++ b/rtl/axil2apb.v
@@ -718,3 +718,7 @@ module	axil2apb #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axil2axis.v
+++ b/rtl/axil2axis.v
@@ -878,3 +878,7 @@ module	axil2axis #(
 	// }}}
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axilempty.v
+++ b/rtl/axilempty.v
@@ -354,3 +354,7 @@ module	axilempty #(
 	// }}}
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axilfetch.v
+++ b/rtl/axilfetch.v
@@ -375,3 +375,7 @@ module	axilfetch #(
 	// Formal properties for this module are maintained elsewhere
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axilsafety.v
+++ b/rtl/axilsafety.v
@@ -1391,3 +1391,7 @@ module axilsafety #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axim2wbsp.v
+++ b/rtl/axim2wbsp.v
@@ -281,3 +281,7 @@ module axim2wbsp #(
 `ifdef	FORMAL
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/aximrd2wbsp.v
+++ b/rtl/aximrd2wbsp.v
@@ -601,3 +601,7 @@ module	aximrd2wbsp #(
 
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/aximwr2wbsp.v
+++ b/rtl/aximwr2wbsp.v
@@ -571,3 +571,7 @@ module aximwr2wbsp #(
 		cover(cvr_wrid_bursts == 4);
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axiperf.v
+++ b/rtl/axiperf.v
@@ -1171,3 +1171,7 @@ module	axiperf #(
 	// }}}
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axis2mm.v
+++ b/rtl/axis2mm.v
@@ -1807,3 +1807,7 @@ module	axis2mm #(
 `endif
 	// }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axisgdma.v
+++ b/rtl/axisgdma.v
@@ -1085,3 +1085,7 @@ module	axisgdma #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axisgfsm.v
+++ b/rtl/axisgfsm.v
@@ -1037,3 +1037,7 @@ module	axisgfsm #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axisrandom.v
+++ b/rtl/axisrandom.v
@@ -134,3 +134,7 @@ module	axisrandom #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axissafety.v
+++ b/rtl/axissafety.v
@@ -675,3 +675,7 @@ module	axissafety #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axisswitch.v
+++ b/rtl/axisswitch.v
@@ -614,3 +614,7 @@ module	axisswitch #(
 `endif
 	// }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axivcamera.v
+++ b/rtl/axivcamera.v
@@ -1229,3 +1229,7 @@ module	axivcamera #(
 	// }}}
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axivdisplay.v
+++ b/rtl/axivdisplay.v
@@ -1437,3 +1437,7 @@ module	axivdisplay #(
 	// }}}
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axivfifo.v
+++ b/rtl/axivfifo.v
@@ -1397,3 +1397,7 @@ module	axivfifo #(
 	// }}}
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axixbar.v
+++ b/rtl/axixbar.v
@@ -2475,3 +2475,7 @@ module	axixbar #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/axixclk.v
+++ b/rtl/axixclk.v
@@ -307,3 +307,7 @@ module axixclk #(
 	end endgenerate
 
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/easyaxil.v
+++ b/rtl/easyaxil.v
@@ -439,3 +439,7 @@ module	easyaxil #(
 	// }}}
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/sfifothresh.v
+++ b/rtl/sfifothresh.v
@@ -95,3 +95,7 @@ module sfifothresh(i_clk, i_reset,
 		assert(o_int == (o_fill >= $past(i_threshold)));
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/wbm2axisp.v
+++ b/rtl/wbm2axisp.v
@@ -1145,3 +1145,7 @@ module wbm2axisp #(
 `endif // FORMAL
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/wbsafety.v
+++ b/rtl/wbsafety.v
@@ -523,3 +523,7 @@ module wbsafety(i_clk, i_reset,
 
 `endif
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif

--- a/rtl/wbxclk.v
+++ b/rtl/wbxclk.v
@@ -837,3 +837,7 @@ module	wbxclk #(
 `endif
 // }}}
 endmodule
+
+`ifndef YOSYS
+`default_nettype wire
+`endif


### PR DESCRIPTION
Hi Dan,

Many modules set the define for default nettype to none, and while I agree it's a good practice to have it set this way, it becomes a problem when integrating any of these into a project with 3rd party modules that may not specify the nettype for wires (since the scope of the define is global).
In this PR I'm simply restoring the default nettype to wire at the end of each file that set it to "none" to limit the scope of it, in case you consider it appropriate. I saw it is done in some places only for synth without Yosys, I'm not sure why but I kept it the same way for consistency.