### PR TITLE
axi2wb: Fix invalid sel value when reading

### DIFF
--- a/rtl/axim2wbsp.v
+++ b/rtl/axim2wbsp.v
@@ -268,7 +268,7 @@ module axim2wbsp #(
 		assign	o_wb_we   = r_wb_we;
 		assign	o_wb_addr = r_wb_addr;
 		assign	o_wb_data = 0;
-		assign	o_wb_sel  = 0;
+		assign	o_wb_sel  = {(C_AXI_DATA_WIDTH/8){1'b1}};
 		assign	r_wb_ack  = i_wb_ack;
 		assign	r_wb_stall= i_wb_stall;
 		assign	r_wb_ack  = i_wb_ack;
@@ -292,7 +292,7 @@ module axim2wbsp #(
 		// {{{
 		wbarbiter	#(.DW(DW), .AW(AW))
 		readorwrite(S_AXI_ACLK, o_reset,
-			r_wb_cyc, r_wb_stb, r_wb_we, r_wb_addr, w_wb_data, w_wb_sel,
+			r_wb_cyc, r_wb_stb, r_wb_we, r_wb_addr, w_wb_data, {(C_AXI_DATA_WIDTH/8){1'b1}},
 				r_wb_ack, r_wb_stall, r_wb_err,
 			w_wb_cyc, w_wb_stb, w_wb_we, w_wb_addr, w_wb_data, w_wb_sel,
 				w_wb_ack, w_wb_stall, w_wb_err,

--- a/rtl/axlite2wbsp.v
+++ b/rtl/axlite2wbsp.v
@@ -272,7 +272,7 @@ module axlite2wbsp( i_clk, i_axi_reset_n,
 		assign	o_wb_we   = 1'b0;
 		assign	o_wb_addr = r_wb_addr;
 		assign	o_wb_data = 32'h0;
-		assign	o_wb_sel  = 0;
+		assign	o_wb_sel  = {(C_AXI_DATA_WIDTH/8){1'b1}};
 		assign	r_wb_ack  = i_wb_ack;
 		assign	r_wb_stall= i_wb_stall;
 		assign	r_wb_ack  = i_wb_ack;
@@ -335,7 +335,7 @@ module axlite2wbsp( i_clk, i_axi_reset_n,
 			.F_MAX_STALL(F_MAXSTALL),
 			.F_MAX_ACK_DELAY(F_MAXDELAY))
 			readorwrite(i_clk, !i_axi_reset_n,
-			r_wb_cyc, r_wb_stb, 1'b0, r_wb_addr, w_wb_data, w_wb_sel,
+			r_wb_cyc, r_wb_stb, 1'b0, r_wb_addr, w_wb_data, {(C_AXI_DATA_WIDTH/8){1'b1}},
 				r_wb_ack, r_wb_stall, r_wb_err,
 			w_wb_cyc, w_wb_stb, 1'b1, w_wb_addr, w_wb_data, w_wb_sel,
 				w_wb_ack, w_wb_stall, w_wb_err,


### PR DESCRIPTION
[Wishbone spec](https://wishbone-interconnect.readthedocs.io/en/latest/02_interface.html) writes,

> The select output array SEL_O() indicates where valid data is expected on the DAT_I() signal array during READ cycles, and where it is placed on the DAT_O() signal array during WRITE cycles.

Currently, when data is being read from wishbone slaves, `o_wb_sel` will be set to 0, which means no bit is read. It should be set to all 1.