### PR TITLE
Fixed calculation of sufficiently_filled when the FIFO is full and aw_requests_remaining is less than a maximum burst

### DIFF
--- a/rtl/axis2mm.v
+++ b/rtl/axis2mm.v
@@ -1521,7 +1521,7 @@ module	axis2mm #(
 	if (|aw_requests_remaining[LGLENW-1:LGMAXBURST])
 		sufficiently_filled = |data_available[LGFIFO:LGMAXBURST];
 	else
-		sufficiently_filled = (data_available[LGMAXBURST-1:0]
+		sufficiently_filled = (data_available
 				>= aw_requests_remaining[LGMAXBURST-1:0]);
 
 	//


### PR DESCRIPTION
When aw_requests_remaining is less than `1 << LGMAXBURST` the whole of `data_available` should be checked instead of just `data_available[LGMAXBURST-1:0]`, in my case `data_available` was 0x200 so `data_available[LGMAXBURST-1:0]` is 0.

Fixes #69 