### PR TITLE
Fix for issue #78: Resolve Vivado conflicting register initialization…

### DIFF
--- a/rtl/axixbar.v
+++ b/rtl/axixbar.v
@@ -363,20 +363,20 @@ module	axixbar #(
 	reg	[NSFULL-1:0]	rrequested		[0:NM];
 	reg	[NS:0]		wgrant			[0:NM-1];
 	reg	[NS:0]		rgrant			[0:NM-1];
-	reg	[NM-1:0]	mwgrant;
-	reg	[NM-1:0]	mrgrant;
-	reg	[NS-1:0]	swgrant;
-	reg	[NS-1:0]	srgrant;
+	reg	[NM-1:0]	mwgrant = 0;
+	reg	[NM-1:0]	mrgrant = 0;
+	reg	[NS-1:0]	swgrant = 0;
+	reg	[NS-1:0]	srgrant = 0;
 
 	// verilator lint_off UNUSED
 	wire	[LGMAXBURST-1:0]	w_mawpending	[0:NM-1];
 	wire	[LGMAXBURST-1:0]	wlasts_pending	[0:NM-1];
 	wire	[LGMAXBURST-1:0]	w_mrpending	[0:NM-1];
 	// verilator lint_on  UNUSED
-	reg	[NM-1:0]		mwfull;
-	reg	[NM-1:0]		mrfull;
-	reg	[NM-1:0]		mwempty;
-	reg	[NM-1:0]		mrempty;
+	reg	[NM-1:0]		mwfull = 0;
+	reg	[NM-1:0]		mrfull = 0;
+	reg	[NM-1:0]		mwempty = {NM{1'b1}};
+	reg	[NM-1:0]		mrempty = {NM{1'b1}};
 	//
 	wire	[LGNS-1:0]		mwindex	[0:NMFULL-1];
 	wire	[LGNS-1:0]		mrindex	[0:NMFULL-1];
@@ -415,11 +415,11 @@ module	axixbar #(
 	wire	[3:0]				m_arqos		[0:NMFULL-1];
 	//
 	//
-	reg	[NM-1:0]			berr_valid;
+	reg	[NM-1:0]			berr_valid = 0;
 	reg	[IW-1:0]			berr_id		[0:NM-1];
 	//
-	reg	[NM-1:0]			rerr_none;
-	reg	[NM-1:0]			rerr_last;
+	reg	[NM-1:0]			rerr_none = {NM{1'b1}};
+	reg	[NM-1:0]			rerr_last = 0;
 	reg	[8:0]				rerr_outstanding [0:NM-1];
 	reg	[IW-1:0]			rerr_id		 [0:NM-1];
 
@@ -1185,8 +1185,6 @@ module	axixbar #(
 		// {{{
 		// Now that we've done our homework, we can switch grants
 		// if necessary
-		initial	wgrant[N]  = 0;
-		initial	mwgrant[N] = 0;
 		always @(posedge S_AXI_ACLK)
 		if (!S_AXI_ARESETN)
 		begin
@@ -1366,8 +1364,6 @@ module	axixbar #(
 
 		// READ GRANT ALLOCATION
 		// {{{
-		initial	rgrant[N]  = 0;
-		initial	mrgrant[N] = 0;
 		always @(posedge S_AXI_ACLK)
 		if (!S_AXI_ARESETN)
 		begin
@@ -1510,7 +1506,6 @@ module	axixbar #(
 		// has won arbitration and so has a grant to that slave.
 
 		// swgrant: write arbitration
-		initial	swgrant = 0;
 		always @(*)
 		begin
 			swgrant[M] = 0;
@@ -1519,7 +1514,6 @@ module	axixbar #(
 				swgrant[M] = 1;
 		end
 
-		initial	srgrant = 0;
 		// srgrant: read arbitration
 		always @(*)
 		begin
@@ -1830,7 +1824,6 @@ module	axixbar #(
 
 		// Write error (no slave selected) state machine
 		// {{{
-		initial	berr_valid[N] = 0;
 		always @(posedge S_AXI_ACLK)
 		if (!S_AXI_ARESETN)
 			berr_valid[N] <= 0;
@@ -1968,8 +1961,6 @@ module	axixbar #(
 		// and mwfull, are there to keep us from checking awempty==0
 		// and &awempty respectively.
 		initial	awpending    = 0;
-		initial	mwempty[N]   = 1;
-		initial	mwfull[N]    = 0;
 		always @(posedge S_AXI_ACLK)
 		if (!S_AXI_ARESETN)
 		begin
@@ -2052,8 +2043,6 @@ module	axixbar #(
 		// analogous definitions to mwempty and mwfull, being equal to
 		// rpending == 0 and (&rpending) respectfully.
 		initial	rpending     = 0;
-		initial	mrempty[N]   = 1;
-		initial	mrfull[N]    = 0;
 		always @(posedge S_AXI_ACLK)
 		if (!S_AXI_ARESETN)
 		begin
@@ -2086,9 +2075,6 @@ module	axixbar #(
 		// rerr_last is true on the last of these read beats,
 		// equivalent to rerr_outstanding == 1, and rerr_none is true
 		// when the error state machine is idle
-		initial	rerr_outstanding[N] = 0;
-		initial	rerr_last[N] = 0;
-		initial	rerr_none[N] = 1;
 		always @(posedge S_AXI_ACLK)
 		if (!S_AXI_ARESETN)
 		begin


### PR DESCRIPTION
Fixes #78

Warnings in axixbar.v

[Synth 8-11375] Found 'W3_ARBITRATE_WRITE_REQUESTS[0].mwgrant_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":1194]
[Synth 8-11375] Found 'R3_ARBITRATE_READ_REQUESTS[0].mrgrant_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":1375]
[Synth 8-11375] Found 'W7_COUNT_PENDING_WRITES[0].mwfull_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":1978]
[Synth 8-11375] Found 'R7_COUNT_PENDING_READS[0].mrfull_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":2062]
[Synth 8-11375] Found 'W7_COUNT_PENDING_WRITES[0].mwempty_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":1977]
[Synth 8-11375] Found 'R7_COUNT_PENDING_READS[0].mrempty_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":2061]
[Synth 8-11375] Found 'W6_WRITE_RETURN_CHANNEL[0].berr_valid_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":1836]
[Synth 8-11375] Found 'R7_COUNT_PENDING_READS[0].rerr_none_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":2097]
[Synth 8-11375] Found 'R7_COUNT_PENDING_READS[0].rerr_last_reg' register with conflicting initialization ["./wb2axip/rtl/axixbar.v":2096]


These are Vivado synthesis warnings about registers in the axixbar.v (AXI crossbar from wb2axip) having conflicting initialization values. This is a known issue with the wb2axip library.

The warnings are caused by conflicting initial values in the wb2axip Verilog code. The pattern is:

```
initial mwgrant[N] = 0;      // Line 1189 - initial block sets to 0
always @(posedge S_AXI_ACLK)
if (!S_AXI_ARESETN)
    mwgrant[N] <= 0;         // Line 1194 - reset sets to 0 (but Vivado sees potential conflict)
```
	
	
In Verilog/SystemVerilog for Xilinx FPGAs, you can do this similarly to VHDL by using inline initialization instead of a separate initial block. I applied the same method.


```
reg mwgrant = 1'b0;       // Inline initialization at declaration

always @(posedge clk)
    if (!resetn)
        mwgrant <= 1'b0;  // Reset
    else
        mwgrant <= ...;
```

I tested it by adding changes to Vivado and synthesize it again in a project. It worked fine.
